### PR TITLE
deps:: Chage base64 encoding and decoding to 0.21.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -386,6 +386,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bech32"
@@ -790,7 +796,7 @@ version = "0.1.0"
 source = "git+https://github.com/decentnetwork/decentnet_protocol.git#0bde4c5e600f5487c58cd1a25e094ab23e7c943e"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "koibumi-base32",
  "rmp-serde",
  "serde",
@@ -2890,7 +2896,7 @@ dependencies = [
  "actix-web-actors",
  "async-recursion",
  "async-trait",
- "base64",
+ "base64 0.21.0",
  "bincode",
  "bitcoin 0.29.2",
  "clap",
@@ -2935,7 +2941,7 @@ name = "zeronet_cryptography"
 version = "0.2.0"
 source = "git+https://github.com/decentnetwork/zeronet_cryptography.git#750d47698c45946f0f60a033553088ef995f3c22"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bitcoin 0.25.2",
  "hex",
  "ripemd160",
@@ -2949,7 +2955,7 @@ name = "zeronet_protocol"
 version = "0.1.10"
 source = "git+https://github.com/decentnetwork/zeronet_protocol.git?branch=decentnet#9ce8fabb17b7426a601f46136297de581d691413"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "decentnet_protocol",
  "futures",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.4-beta"
 [dependencies]
 async-recursion = "1.0.0"
 async-trait = "0.1.52"
-base64 = "0.13.0"
+base64 = "0.21.0"
 bincode = "1.3.3"
 bitcoin = "0.29.2"
 clap = "4.0.19"

--- a/src/plugins/site_server/common.rs
+++ b/src/plugins/site_server/common.rs
@@ -4,6 +4,7 @@ use actix_web::{
 };
 use rand::{rngs::OsRng, Rng};
 use regex::Regex;
+use base64::{engine::general_purpose, Engine as _};
 
 pub fn redirect(path: &str) -> HttpResponse {
     let mut resp = HttpResponse::PermanentRedirect();
@@ -89,7 +90,7 @@ pub fn get_nonce(need_base_64: bool, length: usize) -> String {
     let mut rand = OsRng::default();
     rand.fill(&mut bytes);
     if need_base_64 {
-        let rand_str = base64::encode(bytes).chars().take(length).collect();
+        let rand_str = general_purpose::STANDARD.encode(bytes).chars().take(length).collect();
         rand_str
     } else {
         let rand_str = hex::encode(bytes).chars().take(length).collect();

--- a/src/plugins/site_server/common.rs
+++ b/src/plugins/site_server/common.rs
@@ -2,9 +2,9 @@ use actix_web::{
     http::header::{self, AsHeaderName, HeaderValue},
     HttpRequest, HttpResponse,
 };
+use base64::{engine::general_purpose, Engine as _};
 use rand::{rngs::OsRng, Rng};
 use regex::Regex;
-use base64::{engine::general_purpose, Engine as _};
 
 pub fn redirect(path: &str) -> HttpResponse {
     let mut resp = HttpResponse::PermanentRedirect();
@@ -90,7 +90,11 @@ pub fn get_nonce(need_base_64: bool, length: usize) -> String {
     let mut rand = OsRng::default();
     rand.fill(&mut bytes);
     if need_base_64 {
-        let rand_str = general_purpose::STANDARD.encode(bytes).chars().take(length).collect();
+        let rand_str = general_purpose::STANDARD
+            .encode(bytes)
+            .chars()
+            .take(length)
+            .collect();
         rand_str
     } else {
         let rand_str = hex::encode(bytes).chars().take(length).collect();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod diff;
 pub mod msgpack;
 
+use base64::{engine::general_purpose, Engine as _};
 use std::default::Default;
 
 use rusqlite::types::{Type, Value};
@@ -11,7 +12,7 @@ pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 
 pub fn gen_peer_id() -> String {
     let vec: Vec<u8> = (0..12).map(|_| rand::random::<u8>()).collect();
-    let peer_id = format!("-UT3530-{}", base64::encode(vec));
+    let peer_id = format!("-UT3530-{}", general_purpose::STANDARD.encode(vec));
     peer_id
 }
 


### PR DESCRIPTION
Updated the encoding and decoding methods which are deprecated